### PR TITLE
Backend assignment.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,6 +61,7 @@
         "drupal/migrate_plus": "^6.0",
         "drupal/migrate_source_csv": "^3.4",
         "drupal/migrate_tools": "^6.0",
+        "drupal/og": "^2.0@alpha",
         "drupal/pantheon_advanced_page_cache": "^2.2",
         "drupal/paragraphs": "^1.17",
         "drupal/paragraphs_edit": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9b3cb6d0fc0f78a87dab4d7a6748fdd9",
+    "content-hash": "81566670fdfe1efc5e06c2d715ba66ef",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4428,6 +4428,109 @@
                 "source": "https://git.drupalcode.org/project/migrate_tools",
                 "issues": "https://www.drupal.org/project/issues/migrate_tools",
                 "slack": "#migrate"
+            }
+        },
+        {
+            "name": "drupal/og",
+            "version": "2.0.0-alpha1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/og.git",
+                "reference": "2.0.0-alpha1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/og-2.0.0-alpha1.zip",
+                "reference": "2.0.0-alpha1",
+                "shasum": "8716eaad445b1a909047afe6ff98cc1c1494237f"
+            },
+            "require": {
+                "drupal/core": "^10.3 || ^11"
+            },
+            "require-dev": {
+                "drupal/coder": "^8.3.16",
+                "drush/drush": "^12.5 || ^13.3",
+                "phpunit/phpunit": "^7 || ^8 || ^9 || ^10.5"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.0-alpha1",
+                    "datestamp": "1744224067",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Alpha releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "amitaibu",
+                    "homepage": "https://www.drupal.org/u/amitaibu"
+                },
+                {
+                    "name": "mpp",
+                    "homepage": "https://www.drupal.org/u/mpp"
+                },
+                {
+                    "name": "pfrenssen",
+                    "homepage": "https://www.drupal.org/u/pfrenssen"
+                },
+                {
+                    "name": "dries",
+                    "homepage": "https://www.drupal.org/user/1"
+                },
+                {
+                    "name": "dww",
+                    "homepage": "https://www.drupal.org/user/46549"
+                },
+                {
+                    "name": "Grayside",
+                    "homepage": "https://www.drupal.org/user/346868"
+                },
+                {
+                    "name": "joelpittet",
+                    "homepage": "https://www.drupal.org/user/160302"
+                },
+                {
+                    "name": "merlinofchaos",
+                    "homepage": "https://www.drupal.org/user/26979"
+                },
+                {
+                    "name": "moshe weitzman",
+                    "homepage": "https://www.drupal.org/user/23"
+                },
+                {
+                    "name": "mpp",
+                    "homepage": "https://www.drupal.org/user/359881"
+                },
+                {
+                    "name": "pfrenssen",
+                    "homepage": "https://www.drupal.org/user/382067"
+                },
+                {
+                    "name": "RoySegall",
+                    "homepage": "https://www.drupal.org/user/1812910"
+                },
+                {
+                    "name": "sethcohn",
+                    "homepage": "https://www.drupal.org/user/14944"
+                },
+                {
+                    "name": "Zen",
+                    "homepage": "https://www.drupal.org/user/21209"
+                }
+            ],
+            "description": "API to allow associating content with groups.",
+            "homepage": "https://drupal.org/project/og",
+            "support": {
+                "source": "https://git.drupalcode.org/project/og",
+                "issues": "https://drupal.org/project/issues/og",
+                "slack": "https://drupal.slack.com/messages/CELR48EA0"
             }
         },
         {
@@ -17264,6 +17367,7 @@
         "drupal/default_content": 15,
         "drupal/drupal_test_assertions": 20,
         "drupal/inline_entity_form": 5,
+        "drupal/og": 15,
         "drupal/potx": 15,
         "drupal/ultimate_cron": 15
     },

--- a/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/NodeGroup.php
+++ b/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/NodeGroup.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Drupal\server_general\Plugin\EntityViewBuilder;
+
+use Drupal\node\NodeInterface;
+use Drupal\server_general\EntityDateTrait;
+use Drupal\server_general\EntityViewBuilder\NodeViewBuilderAbstract;
+use Drupal\server_general\ThemeTrait\ElementLayoutThemeTrait;
+use Drupal\server_general\ThemeTrait\ElementNodeGroupThemeTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * The "Node News" plugin.
+ *
+ * @EntityViewBuilder(
+ *   id = "node.group",
+ *   label = @Translation("Node - Group"),
+ *   description = "Node view builder for News bundle."
+ * )
+ */
+class NodeGroup extends NodeViewBuilderAbstract {
+
+  use ElementLayoutThemeTrait;
+  use ElementNodeGroupThemeTrait;
+  use EntityDateTrait;
+
+  /**
+   * The renderer.
+   *
+   * This is not used in this file, but the `SearchThemeTrait` uses it.
+   *
+   * @var \Drupal\Core\Render\RendererInterface
+   */
+  protected $renderer;
+
+  /**
+   * The current user service.
+   *
+   * @var \Drupal\Core\Session\AccountProxyInterface
+   */
+  protected $currentUser;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    $plugin = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $plugin->renderer = $container->get('renderer');
+    $plugin->currentUser = $container->get('current_user');
+
+    return $plugin;
+  }
+
+  /**
+   * Build full view mode.
+   *
+   * @param array $build
+   *   The existing build.
+   * @param \Drupal\node\NodeInterface $entity
+   *   The entity.
+   *
+   * @return array
+   *   Render array.
+   */
+  public function buildFull(array $build, NodeInterface $entity) {
+    // The hero responsive image.
+    $medias = $entity->get('field_featured_image')->referencedEntities();
+    $image = $this->buildEntities($medias, 'hero');
+
+    $element = $this->buildElementNodeGroup(
+      $entity->label(),
+      $this->getFieldOrCreatedTimestamp($entity, (string) $entity->getCreatedTime()),
+      $image,
+      $this->buildProcessedText($entity),
+      $this->currentUser,
+      group_id: $entity->id()
+    );
+
+    $build[] = $element;
+
+    return $build;
+  }
+
+}

--- a/web/modules/custom/server_general/src/ThemeTrait/ElementNodeGroupThemeTrait.php
+++ b/web/modules/custom/server_general/src/ThemeTrait/ElementNodeGroupThemeTrait.php
@@ -138,6 +138,16 @@ trait ElementNodeGroupThemeTrait {
       );
     }
 
+    $membership = \Drupal::entityTypeManager()
+      ->getStorage('og_membership')
+      ->loadByProperties([
+        'uid' => $account->id(),
+        'entity_type' => $group->getEntityTypeId(),
+        'entity_id' => $group->id(),
+      ]);
+    /** @var \Drupal\og\OgMembershipInterface */
+    $membership = reset($membership);
+
     // Check if the user already a member of the group.
     if (Og::isMember($group, $account)) {
       $sidebar_elements[] = [
@@ -148,21 +158,25 @@ trait ElementNodeGroupThemeTrait {
         )),
       ];
     }
-    elseif (!empty(\Drupal::entityTypeManager()
-      ->getStorage('og_membership')
-      ->loadByProperties([
-        'uid' => $account->id(),
-        'entity_type' => $group->getEntityTypeId(),
-        'entity_id' => $group->id(),
-        'state' => OgMembershipInterface::STATE_PENDING,
-      ]))) {
-      $sidebar_elements[] = [
-        '#markup' => Markup::create(sprintf(
-          'Hi %s, you already have a pending membership for the the group: %s',
-          $current_user->getAccount()->getDisplayName(),
-          $title
-        )),
-      ];
+    elseif (!empty($membership)) {
+      if ($membership->getState() == OgMembershipInterface::STATE_PENDING) {
+        $sidebar_elements[] = [
+          '#markup' => Markup::create(sprintf(
+            'Hi %s, you already have a pending membership for the the group: %s',
+            $current_user->getAccount()->getDisplayName(),
+            $title
+          )),
+        ];
+      }
+      elseif ($membership->getState() == OgMembershipInterface::STATE_BLOCKED) {
+        $sidebar_elements[] = [
+          '#markup' => Markup::create(sprintf(
+            'Hi %s, your request to join the group "%s" has been blocked.',
+            $account->getDisplayName(),
+            $title
+          )),
+        ];
+      }
     }
     else {
       $sidebar_elements[] = [

--- a/web/modules/custom/server_general/src/ThemeTrait/ElementNodeGroupThemeTrait.php
+++ b/web/modules/custom/server_general/src/ThemeTrait/ElementNodeGroupThemeTrait.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\server_general\ThemeTrait;
+
+use Drupal\Core\Render\Markup;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\intl_date\IntlDate;
+use Drupal\og\Og;
+use Drupal\og\OgMembershipInterface;
+use Drupal\server_general\EntityDateTrait;
+
+/**
+ * Helper method for building the Node group element.
+ */
+trait ElementNodeGroupThemeTrait {
+
+  use ElementWrapThemeTrait;
+  use EntityDateTrait;
+  use InnerElementLayoutThemeTrait;
+  use LineSeparatorThemeTrait;
+  use ElementLayoutThemeTrait;
+  use TitleAndLabelsThemeTrait;
+
+  /**
+   * Build the Group news element.
+   *
+   * @param string $title
+   *   The node title.
+   * @param int $timestamp
+   *   The timestamp.
+   * @param array $image
+   *   The responsive image render array.
+   * @param array $body
+   *   The body render array.
+   * @param \Drupal\Core\Session\AccountProxyInterface $current_user
+   *   The current user object.
+   * @param int $group_id
+   *   The current Group entity ID.
+   *
+   * @return array
+   *   The render array.
+   *
+   * @throws \IntlException
+   */
+  protected function buildElementNodeGroup(string $title, int $timestamp, array $image, array $body, AccountProxyInterface $current_user, int $group_id): array {
+    $elements = [];
+
+    // Header.
+    $element = $this->buildHeader(
+      $title,
+      $timestamp
+    );
+    $elements[] = $this->wrapContainerWide($element);
+
+    // Main content and sidebar.
+    $element = $this->buildMainAndSidebar(
+      $title,
+      $image,
+      $this->wrapProseText($body),
+      $current_user,
+      $group_id
+    );
+    $elements[] = $this->wrapContainerWide($element);
+
+    $elements = $this->wrapContainerVerticalSpacingBig($elements);
+    return $this->wrapContainerBottomPadding($elements);
+  }
+
+  /**
+   * Build the header.
+   *
+   * @param string $title
+   *   The node title.
+   * @param int $timestamp
+   *   The timestamp.
+   *
+   * @return array
+   *   Render array.
+   *
+   * @throws \IntlException
+   */
+  private function buildHeader(string $title, int $timestamp): array {
+    $elements = [];
+
+    $elements[] = $this->buildPageTitle($title);
+
+    // Date.
+    $element = IntlDate::formatPattern($timestamp, 'long');
+
+    // Make text bigger.
+    $elements[] = $this->wrapTextResponsiveFontSize($element, FontSizeEnum::LG);
+
+    $elements = $this->wrapContainerVerticalSpacing($elements);
+
+    return $this->wrapContainerMaxWidth($elements, WidthEnum::ThreeXl);
+  }
+
+  /**
+   * Build the Main content and the sidebar.
+   *
+   * @param string $title
+   *   The node title.
+   * @param array $image
+   *   The responsive image render array.
+   * @param array $body
+   *   The body render array.
+   * @param \Drupal\Core\Session\AccountProxyInterface $current_user
+   *   The current user object.
+   * @param int $group_id
+   *   The current Group entity ID.
+   *
+   * @return array
+   *   Render array
+   */
+  private function buildMainAndSidebar(string $title, array $image, array $body, AccountProxyInterface $current_user, int $group_id): array {
+    $main_elements = [];
+    $sidebar_elements = [];
+
+    $main_elements = [$image, $body];
+
+    $group = \Drupal::routeMatch()->getParameter('node');
+    $account = $current_user->getAccount();
+
+    // Check if the user is anonymous & return early.
+    if ($account->isAnonymous()) {
+      $sidebar_elements[] = [
+        '#markup' => Markup::create(sprintf(
+          'Please <a href="/user/login">Log in</a> to your account subscribe to the group: %s',
+          $title
+        )),
+      ];
+
+      return $this->buildElementLayoutMainAndSidebar(
+        $this->wrapContainerVerticalSpacingBig($main_elements),
+        $this->buildInnerElementLayout($this->wrapRoundedCornersBig($sidebar_elements)),
+      );
+    }
+
+    // Check if the user already a member of the group.
+    if (Og::isMember($group, $account)) {
+      $sidebar_elements[] = [
+        '#markup' => Markup::create(sprintf(
+          'Hi %s, you are already subscribed to the group: %s',
+          $current_user->getAccount()->getDisplayName(),
+          $title
+        )),
+      ];
+    }
+    elseif (!empty(\Drupal::entityTypeManager()
+      ->getStorage('og_membership')
+      ->loadByProperties([
+        'uid' => $account->id(),
+        'entity_type' => $group->getEntityTypeId(),
+        'entity_id' => $group->id(),
+        'state' => OgMembershipInterface::STATE_PENDING,
+      ]))) {
+      $sidebar_elements[] = [
+        '#markup' => Markup::create(sprintf(
+          'Hi %s, you already have a pending membership for the the group: %s',
+          $current_user->getAccount()->getDisplayName(),
+          $title
+        )),
+      ];
+    }
+    else {
+      $sidebar_elements[] = [
+        '#markup' => Markup::create(sprintf(
+          'Hi %s, <a href="/group/node/%d/subscribe">Click Here</a> if you would like to subscribe to this group: %s',
+          $current_user->getAccount()->getDisplayName(),
+          $group_id,
+          $title
+        )),
+      ];
+    }
+
+    return $this->buildElementLayoutMainAndSidebar(
+      $this->wrapContainerVerticalSpacingBig($main_elements),
+      $this->buildInnerElementLayout($this->wrapRoundedCornersBig($sidebar_elements)),
+    );
+  }
+
+}

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralNodeGroupTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralNodeGroupTest.php
@@ -127,4 +127,28 @@ class ServerGeneralNodeGroupTest extends ServerGeneralTestBase {
     $this->drupalLogout();
   }
 
+  /**
+   * Test blocked state for users.
+   *
+   * @throws \Behat\Mink\Exception\ExpectationException
+   */
+  public function testGroupAccessForBlocked()
+  {
+    $user = $this->createUser([], 'FooBar');
+
+    OgMembership::create([
+      'type' => 'og_membership',
+      'entity_type' => 'node',
+      'entity_id' => $this->node->id(),
+      'uid' => $user->id(),
+      'state' => OgMembershipInterface::STATE_BLOCKED,
+    ])->save();
+
+    $this->drupalLogin($user);
+    $this->drupalGet($this->node->toUrl());
+    $this->assertSession()->statusCodeEquals(Response::HTTP_OK);
+    $this->assertSession()->pageTextContains('Hi FooBar, your request to join the group "Llama" has been blocked.');
+    $this->drupalLogout();
+  }
+
 }

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralNodeGroupTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralNodeGroupTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Drupal\Tests\server_general\ExistingSite;
+
+use Drupal\og\Entity\OgMembership;
+use Drupal\og\OgMembershipInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * A model test case using traits from Drupal Test Traits.
+ */
+class ServerGeneralNodeGroupTest extends ServerGeneralTestBase {
+  /**
+   * The node entity used in the test.
+   *
+   * @var \Drupal\node\NodeInterface
+   */
+  protected $node;
+
+  /**
+   * The user entity used in the test.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $user;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->user = $this->createUser([
+      'edit own group content',
+    ], 'JohnDoe');
+
+    $this->node = $this->createNode([
+      'title' => 'Llama',
+      'type' => 'group',
+      'uid' => $this->user->id(),
+      'field_body' => 'This is the text of the body field.',
+      'field_featured_image' => ['target_id' => 1],
+      'status' => 1,
+    ]);
+  }
+
+  /**
+   * Test permissions and content access for author.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   * @throws \Drupal\Core\Entity\EntityMalformedException
+   * @throws \Behat\Mink\Exception\ExpectationException
+   */
+  public function testGroup() {
+    $this->assertEquals($this->user->id(), $this->node->getOwnerId());
+
+    // We can browse pages.
+    $this->drupalGet($this->node->toUrl());
+    $this->assertSession()->statusCodeEquals(Response::HTTP_OK);
+
+    // We can login and browse admin pages.
+    $this->drupalLogin($this->user);
+    $this->drupalGet($this->node->toUrl('edit-form'));
+  }
+
+  /**
+   * Test Group access for Owners and Existing Members.
+   *
+   * @throws \Behat\Mink\Exception\ExpectationException
+   */
+  public function testGroupAccessForOwnerAndExistingMember() {
+    $this->drupalLogin($this->user);
+    $this->drupalGet($this->node->toUrl());
+    $this->assertSession()->pageTextContains('Hi JohnDoe, you are already subscribed to the group: Llama');
+    $this->drupalLogout();
+  }
+
+  /**
+   * Test Group access for Anonymous users.
+   *
+   * @throws \Behat\Mink\Exception\ExpectationException
+   */
+  public function testGroupAccessForAnonymous() {
+    $this->drupalGet($this->node->toUrl());
+    $this->assertSession()->statusCodeEquals(Response::HTTP_OK);
+    $this->assertSession()->linkExists('Log in');
+    $this->assertSession()->pageTextContains('Please Log in to your account subscribe to the group: Llama');
+  }
+
+  /**
+   * Test Group access for Authenticated users.
+   *
+   * @throws \Behat\Mink\Exception\ExpectationException
+   */
+  public function testGroupAccessForAuthenticated() {
+    $user = $this->createUser([], 'FooBar');
+    $this->drupalLogin($user);
+    $this->drupalGet($this->node->toUrl());
+    $this->assertSession()->statusCodeEquals(Response::HTTP_OK);
+    $this->assertSession()->linkExists('Click Here');
+    $link = $this->getSession()->getPage()->findLink('Click Here');
+    $this->assertNotNull($link);
+    $this->assertEquals('/group/node/' . $this->node->id() . '/subscribe', $link->getAttribute('href'));
+    $this->assertSession()->pageTextContains('Hi FooBar, Click Here if you would like to subscribe to this group: Llama');
+    $this->drupalLogout();
+  }
+
+  /**
+   * Test pending group approval.
+   *
+   * @throws \Behat\Mink\Exception\ExpectationException
+   */
+  public function testGroupAccessForPendingApproval() {
+    $user = $this->createUser([], 'FooBar');
+
+    OgMembership::create([
+      'type' => 'og_membership',
+      'entity_type' => 'node',
+      'entity_id' => $this->node->id(),
+      'uid' => $user->id(),
+      'state' => OgMembershipInterface::STATE_PENDING,
+    ])->save();
+
+    $this->drupalLogin($user);
+    $this->drupalGet($this->node->toUrl());
+    $this->assertSession()->statusCodeEquals(Response::HTTP_OK);
+    $this->assertSession()->pageTextContains('Hi FooBar, you already have a pending membership for the the group: Llama');
+    $this->drupalLogout();
+  }
+
+}


### PR DESCRIPTION
### As an authenticated user, when the user is not a member of the group
<img width="1792" alt="Screenshot 2025-05-26 at 11 50 11 PM" src="https://github.com/user-attachments/assets/0261f155-77a3-42c2-bb99-a5d59c83b356" />

### When a user requests membership for a group and has a pending approval
<img width="1792" alt="Screenshot 2025-05-26 at 11 50 32 PM" src="https://github.com/user-attachments/assets/b5fd6b8b-d870-4a83-be55-cce4261ee8bf" />

### When a user is already a member of a group
<img width="1792" alt="Screenshot 2025-05-26 at 11 50 57 PM" src="https://github.com/user-attachments/assets/c6c6bc52-d4c4-4d43-b59a-b23b88b119bf" />

### When an anonymous user visits the group page
<img width="1792" alt="Screenshot 2025-05-26 at 11 51 17 PM" src="https://github.com/user-attachments/assets/ae489c63-f487-4567-9f9a-8d4413e0a93a" />

Post installing the OG module, a content type called Group was created with the Title, Featured Image and Body fields. The configuration changes are added in a different Pull Request [https://github.com/malabya/assignment/pull/2](https://github.com/malabya/assignment/pull/2)
`web/modules/custom/server_general/src/Plugin/EntityViewBuilder/NodeGroup.php` was added for the Full node view of a Group content. The Plugin passes the fields to the `buildElementNodeGroup` method in `web/modules/custom/server_general/src/ThemeTrait/ElementNodeGroupThemeTrait.php`. The method `buildElementNodeGroup` reuses the methods `buildHeader` & `buildMainAndSidebar`. The message to the user is shown in the sidebar of the content. The logic for handling the Og access and memberships is handled in the `buildMainAndSidebar` method checking the user account object and membership data. It returns early for anonymous users. 

Tests are added for each of the user access cases in `web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralNodeGroupTest.php`
